### PR TITLE
Evidence: davxy-2024-H1 - retain rank II

### DIFF
--- a/evidence/davxy/0001-davxy-2024-H1.md
+++ b/evidence/davxy/0001-davxy-2024-H1.md
@@ -18,7 +18,7 @@
 
 ## Reporting period
 
-- Start date: 2023/01/08
+- Start date: 2024/01/08
 - End date: 2024/05/13
 
 
@@ -27,7 +27,7 @@
 ### JAM
 
 - Gray Paper.
-  - Actively contributed to and reviewed the Safrole consensus protocol design ([GP acknowledgements](https://github.com/gavofyork/graypaper/blob/main/text/ack.tex)).
+  - Actively contributed to and reviewed the Safrole consensus protocol design ([GP acknowledgments](https://github.com/gavofyork/graypaper/blob/main/text/ack.tex)).
 
 - Bandersnatch Verifiable Random Functions (VRFs)
   - Co-authored the formal specification of Bandersnatch VRFs with Seyed Hosseini, critical for the cryptographic processes in both the Safrole and Sassafras protocols  ([Specification](https://github.com/davxy/bandersnatch-vrfs-spec), [GP bibliography](https://github.com/gavofyork/graypaper/blob/3222bb39f3d6121c7fe86fa33a9620d43b558476/biblio.bib#L303)).

--- a/evidence/davxy/0001-davxy-2024-H1.md
+++ b/evidence/davxy/0001-davxy-2024-H1.md
@@ -1,0 +1,58 @@
+# Evidence-0001: Retention at Rank II
+
+|                  |                      |
+| ---------------- | ---------------------|
+| **Report Date**  | 2024/05/04           |
+| **Submitted by** | Davide Galassi       |
+
+
+## Member details
+
+- Matrix username: @davxy:matrix.org
+- Polkadot address: 16Q4qkRcWd4r8196dVGNLYVfy7H86MJYJBMockPaMigFXCyv
+- Current rank: 2
+- Date of initial induction: 2024/01/08
+- Date of last report: NA
+- Area(s) of Expertise/Interest: Substrate Node, Consensus Protocols, Applied Cryptography
+
+
+## Reporting period
+
+- Start date: 2023/01/08
+- End date: 2024/05/13
+
+
+## Evidence
+
+### JAM
+
+- Gray Paper.
+  - Actively contributed to and reviewed the Safrole consensus protocol design ([GP acknowledgements](https://github.com/gavofyork/graypaper/blob/main/text/ack.tex)).
+
+- Bandersnatch Verifiable Random Functions (VRFs)
+  - Co-authored the formal specification of Bandersnatch VRFs with Seyed Hosseini, critical for the cryptographic processes in both the Safrole and Sassafras protocols  ([Specification](https://github.com/davxy/bandersnatch-vrfs-spec), [GP bibliography](https://github.com/gavofyork/graypaper/blob/3222bb39f3d6121c7fe86fa33a9620d43b558476/biblio.bib#L303)).
+  - Developed a stand-alone library implementing the specification ([CRATE](https://github.com/davxy/ark-ec-vrfs)).
+
+- Development of JAM's Safrole prototype.
+
+### Polkadot-SDK
+
+- Crypto code refactory.
+  - Small refactory to minimize the shared code and reduce the technical debt in the Substrate crypto primitives.
+  - PRs: [SDK 3684](https://github.com/paritytech/polkadot-sdk/pull/3684), [SDK 3806](https://github.com/paritytech/polkadot-sdk/pull/3806)
+
+- Sassafras protocol update.
+  - Initiated the overhaul of Sassafras protocol already integrated in the SDK in order to align it with the updates recently introduced in [RFC 26](https://github.com/polkadot-fellows/RFCs/pull/26). In particular this is an effort to reduce the gap between Safrole and Sassafras.
+  - PR: [SDK 4373](https://github.com/paritytech/polkadot-sdk/pull/4373)
+
+### RFCs
+
+- Resurrect Sassafras
+  - The development of Sassafras RFC had been paused during the design phase of the Safrole protocol.
+    It has now been updated to incorporate some of the ideas and simplifications introduced by Safrole.
+  - PR: [RFC 26](https://github.com/polkadot-fellows/RFCs/pull/26)
+
+### Support and Collaboration
+
+- Review of Polkadot-SDK pull requests that mostly fall within my area of expertise or made by the Node SDK team.
+- Active participation in the JAM Gray paper review process.


### PR DESCRIPTION
Greetings,

I'm presenting evidence here to maintain my current rank II.

This submission encompasses my pertinent activity within the Polkadot ecosystem. 

You can view the rendered version [here](https://github.com/davxy/polkadot-fellows-evidences/blob/main/evidence/davxy/0001-davxy-2024-H1.md).

```
$ b2sum -l 256 0001-davxy-2024-H1.md
e06ac00a2d6d134d1ae51cbc1574ca719578af568a700054f352db356ce2e22c
```