### PR TITLE
Introduce github action automation

### DIFF
--- a/.github/workflows/evidences.action.yml
+++ b/.github/workflows/evidences.action.yml
@@ -1,0 +1,20 @@
+name: Evidences action
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  pull-requests: write
+  contents: write
+
+jobs:
+  evidences-action:
+    name: Handle an Evidence command
+    if: ${{ github.event.issue.pull_request && startsWith(github.event.comment.body, '/evidence') }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: paritytech/evidences-action@59d1296adf6e8da83904b2dfde61f22d1dbea88c # main
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
- Progresses https://github.com/polkadot-fellows/Evidences/issues/4

The action aims to help with hashing the evidence and submitting it to the chain.
It works analogically to the action in the RFC repo, and is in fact an adapted fork of that action.

After an `/evidence submit` command, it will produce a result [like this](https://github.com/rzadp/Evidences/pull/1).

The user has a choice of using the provided PolkadotJS links to send an extrinsic.
Just a hash of the evidence is available too.

There is no functionality to automatically close/merge the PRs yet.