### PR TITLE
Add info about timelines, resources, and on-chain submission via Subsquare

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Evidences are a proof of work to indicate the Fellowship's commitment to impleme
 
 All members that have been inducted for standard allowance as per the [Fellowship Salaries](https://github.com/polkadot-fellows/RFCs/blob/main/text/0050-fellowship-salaries.md) must submit their Evidences once over a period of time (3 months for Rank I-II, 6 months for Rank III-VI) to avoid demotion to a lower rank. 
 
-All members of Ranks II-VI must serve a minimum period of service of 12 months at their current rank before seeking promotion to a higher rank. There is no minimum period of service for Candidates seeking to become members or Rank I members seeking promotion to Rank II.
+All members (Ranks I-VI) must serve a minimum period of service of 12 months at their current rank before seeking promotion to a higher rank. There is no minimum period of service for Candidates seeking to become members.
 
 
 ## Timelines

--- a/README.md
+++ b/README.md
@@ -42,12 +42,12 @@ Evidences are a proof of work to indicate the Fellowship's commitment to impleme
 
 All members that have been inducted for standard allowance as per the [Fellowship Salaries](https://github.com/polkadot-fellows/RFCs/blob/main/text/0050-fellowship-salaries.md) must submit their Evidences once over a period of time (3 months for Rank I-II, 6 months for Rank III-VI) to avoid demotion to a lower rank. 
 
-All members of Rank II-VI must ensure that they have served the minimum period of service (12 months) at their current rank before seeking promotion to a higher rank.
+All members must serve a minimum period of service of 12 months at their current rank before seeking promotion to a higher rank. There is no minimum period of service for candidates seeking to become members.
 
 
 ## Timelines
 
-Members should individually monitor the progress of their demotion period on the [Core Fellowship UI](https://collectives.subsquare.io/fellowship/core) provided by Subsquare. 
+Members should individually monitor the progress of their demotion and promotion periods on the [Core Fellowship UI](https://collectives.subsquare.io/fellowship/core) provided by Subsquare. 
 Members can also add an ical feed for Fellowship-related data directly into their email client or their Google account using this link: **webcal://fellowship-calendar.kchr.de/?account=YOUR_ACCOUNT_ID**. The code for this widget can be found [here](https://github.com/bkchr/fellowship-ical). 
 
 It is recommended that members submit their evidence for review (via GitHub) and on-chain (via Subsquare) as per the following deadlines:

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Members can also add an ical feed for Fellowship-related data directly into thei
 
 It is recommended that members submit their evidence for review (via GitHub) and on-chain (via Subsquare) as per the following deadlines:
 - For retentions: no later than **30 days** prior to the end of the demotion period
-- For promotions: no later than **40 days** prior to the end of the demotion period
+- For promotions: no later than **40 days** prior to the end of the demotion period AND **more than 12 months** after the last promotion
 
 
 ## Process

--- a/README.md
+++ b/README.md
@@ -47,7 +47,8 @@ All members must serve a minimum period of service of 12 months at their current
 
 ## Timelines
 
-Members can individually monitor the progress of their demotion period on the [Core Fellowship UI](https://collectives.subsquare.io/fellowship/core) provided by Subsquare. Members will soon be able to set up an ical feed to set reminders and get updates for their membership status.
+Members should individually monitor the progress of their demotion period on the [Core Fellowship UI](https://collectives.subsquare.io/fellowship/core) provided by Subsquare. 
+Members can also add an ical feed for Fellowship-related data directly into their email client or their Google account using this link: **webcal://fellowship-calendar.kchr.de/?account=YOUR_ACCOUNT_ID**. The code for this widget can be found [here](https://github.com/bkchr/fellowship-ical). 
 
 It is recommended that members submit their evidence for review (via GitHub) and on-chain (via Subsquare) as per the following deadlines:
 - For retentions: no later than **30 days** prior to the end of the demotion period

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Evidences are a proof of work to indicate the Fellowship's commitment to impleme
 
 All members that have been inducted for standard allowance as per the [Fellowship Salaries](https://github.com/polkadot-fellows/RFCs/blob/main/text/0050-fellowship-salaries.md) must submit their Evidences once over a period of time (3 months for Rank I-II, 6 months for Rank III-VI) to avoid demotion to a lower rank. 
 
-All members must serve a minimum period of service of 12 months at their current rank before seeking promotion to a higher rank. 
+All members of Rank II-VI must ensure that they have served the minimum period of service (12 months) at their current rank before seeking promotion to a higher rank.
 
 
 ## Timelines
@@ -52,7 +52,7 @@ Members can also add an ical feed for Fellowship-related data directly into thei
 
 It is recommended that members submit their evidence for review (via GitHub) and on-chain (via Subsquare) as per the following deadlines:
 - For retentions: no later than **30 days** prior to the end of the demotion period
-- For promotions: no later than **40 days** prior to the end of the demotion period AND **more than 12 months** after the last promotion
+- For promotions: no later than **40 days** prior to the end of the demotion period
 
 
 ## Process

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Evidences are a proof of work to indicate the Fellowship's commitment to impleme
 
 All members that have been inducted for standard allowance as per the [Fellowship Salaries](https://github.com/polkadot-fellows/RFCs/blob/main/text/0050-fellowship-salaries.md) must submit their Evidences once over a period of time (3 months for Rank I-II, 6 months for Rank III-VI) to avoid demotion to a lower rank. 
 
-All members must serve a minimum period of service of 12 months at their current rank before seeking promotion to a higher rank. There is no minimum period of service for candidates seeking to become members.
+All members of Ranks II-VI must serve a minimum period of service of 12 months at their current rank before seeking promotion to a higher rank. There is no minimum period of service for Candidates seeking to become members or Rank I members seeking promotion to Rank II.
 
 
 ## Timelines

--- a/README.md
+++ b/README.md
@@ -45,17 +45,26 @@ All members that have been inducted for standard allowance as per the [Fellowshi
 All members must serve a minimum period of service of 12 months at their current rank before seeking promotion to a higher rank. 
 
 
+## Timelines
+
+Members can individually monitor the progress of their demotion period on the [Core Fellowship UI](https://collectives.subsquare.io/fellowship/core) provided by Subsquare. Members can also set up an [ical feed](Link ?? – TBC by wirenkod and bckhr) to set reminders and get updates for their membership.
+
+It is recommended that members submit their evidence for review (via GitHub) and on-chain (via Subsquare) as per the following deadlines:
+- For retentions: no later than **30 days** prior to the end of the demotion period
+- For promotions: no later than **40 days** prior to the end of the demotion period
+
+
 ## Process
 
 The process for submitting Evidences is open to all existing Fellowship members (i.e Rank I to IX). Anyone may provide comments on submitted Evidences.
 
 To submit an Evidence, follow these steps:
-  * Fork the `Evidences` repository
-  * Create a new folder in the `evidence` folder and rename it to match your Github username
-  * Copy the `0000-evidence-template.md` file into the new folder and rename it to match the title of your request
+  * Fork the `Evidences` repository.
+  * Create a new folder in the `evidence` folder and rename it to match your Github username.
+  * Copy the `0000-evidence-template.md` file into the new folder and rename it to match the title of your request.
   * Fill out the Evidence template and open a PR.
-  * Announce the evidence to the fellowship and wait at least one week.
-  * If there are no major push backs by the fellowship, submit the evidence on-chain with the `fellowshipCore.submitEvidence(wish, evidence)` call on the [Polkadot Collectives chain](https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Fsys.ibp.network%2Fcollectives-polkadot#/extrinsics/decode/0x3f0700081230), where *wish* is the nature of the request (Retention or Promotion) and *evidence* is the blake2-256 hash of the raw evidence text.
+  * Announce the evidence to the Fellowship and wait at least one week.
+  * If there are no major pushbacks by the Fellowship, submit the evidence on-chain via the [Core Fellowship UI](https://collectives.subsquare.io/fellowship/core) provided by Subsquare.
 
 Once the request has been approved via on-chain referendum, the PR can be merged. This on-chain process is designed to be resilient to where the Evidences are hosted and in what format, so it can be migrated away from GitHub in the future. The Fellowship should not approve more than one Evidence with the same number. PRs may be closed by their author, when sufficiently stale, or after a period of 6 months without approval. 
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ All members must serve a minimum period of service of 12 months at their current
 
 ## Timelines
 
-Members can individually monitor the progress of their demotion period on the [Core Fellowship UI](https://collectives.subsquare.io/fellowship/core) provided by Subsquare. Members can also set up an [ical feed](Link ?? – TBC by wirenkod and bckhr) to set reminders and get updates for their membership.
+Members can individually monitor the progress of their demotion period on the [Core Fellowship UI](https://collectives.subsquare.io/fellowship/core) provided by Subsquare. Members will soon be able to set up an ical feed to set reminders and get updates for their membership status.
 
 It is recommended that members submit their evidence for review (via GitHub) and on-chain (via Subsquare) as per the following deadlines:
 - For retentions: no later than **30 days** prior to the end of the demotion period

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ All members (Ranks I-VI) must serve a minimum period of service of 12 months at 
 
 ## Timelines
 
-Members should individually monitor the progress of their demotion and promotion periods on the [Core Fellowship UI](https://collectives.subsquare.io/fellowship/core) provided by Subsquare. 
+Members should individually monitor the progress of their demotion and promotion periods on the [Core Fellowship UI](https://collectives.subsquare.io/fellowship/core) provided by Subsquare. Alternatively, members can check their individual status directly on the chain state via [Polkadot-JS](https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Fsys.ibp.network%2Fcollectives-polkadot#/chainstate).
 Members can also add an ical feed for Fellowship-related data directly into their email client or their Google account using this link: **webcal://fellowship-calendar.kchr.de/?account=YOUR_ACCOUNT_ID**. The code for this widget can be found [here](https://github.com/bkchr/fellowship-ical). 
 
 It is recommended that members submit their evidence for review (via GitHub) and on-chain (via Subsquare) as per the following deadlines:


### PR DESCRIPTION
As a follow-up on the recent incident which led to the demotion of 6 members (4 of which had already submitted their evidences on-chain), this PR adds new information in the Evidences docs to:
- give indicative timelines for the on-chain submission process
- direct users to essential membership management resources (existing UI and upcoming calendar)
- update the on-chain submission process to integrate Subsquare, as requested [here](https://github.com/polkadot-fellows/Evidences/issues/15)
