### PR TITLE
Add info about voting records and in-person interviews

### DIFF
--- a/0000-evidence-template.md
+++ b/0000-evidence-template.md
@@ -23,6 +23,7 @@
 
 
 ## Evidence
+*Indicate your contributions in relation to Polkadot SDK.*
 
 |  Areas of Contribution | Tasks  | Links   |Notes   |
 |---|---|---|---|
@@ -31,6 +32,20 @@
 |   |   |   |   |
 |   |   |   |   |
 |   |   |   |   |
+
+
+## Voting record
+*Provide your voting record in relation to required thresholds.* 
+
+|  Ranks | Activity threshold  | Agreement threshold| Link | Notes |
+|---|---|---|---|---|
+|I  |90%   |N/A   | [Votes and Participation rate](https://collectives.subsquare.io/user/15DCWHQknBjc5YPFoVj8Pn2KoqrqYywJJ95BYNYJ4Fj3NLqz/votes) |*This is an example* |
+|I  |90%   |N/A   |   |  |
+|II |80%   |N/A   |   |  |
+|III|70%   |100%  |   |  |
+|IV |60%   |90%   |   |  |
+|V  |50%   |80%   |   |  |
+|VI |40%   |70%   |   |  |
 
 
 ## Misc

--- a/0000-evidence-template.md
+++ b/0000-evidence-template.md
@@ -37,9 +37,9 @@
 ## Voting record
 *Provide your voting record in relation to required thresholds.* 
 
-|  Ranks | Activity thresholds | Agreement thresholds | Links | Comments |
+|  Ranks | Activity thresholds | Agreement thresholds | Member's voting activities | Comments |
 |---|---|---|---|---|
-|III|70%   |100%  |[My votes](https://collectives.subsquare.io/user/13aYUFHB3umoPoxBEAHSv451iR3RpsNi3t5yBZjX2trCtTp6/votes) |*This is an example.* I have *[Never/Sometimes/Often/Always]* voted across all referendum tracks AND *[Never/Sometimes/Often/Always]* voted in line with expectations at rank. |
+|III|70%   |100%  |I have voted on ?? out of ?? referenda available to me, at my current rank (i.e ?? %). Out of ?? referenda where members of higher ranks were in complete agreement, I have voted in the opposite direction ?? times (i.e ?? %).  |*This is an example.* |
 |I  |90%   |N/A   |   |  |
 |II |80%   |N/A   |   |  |
 |III|70%   |100%  |   |  |

--- a/0000-evidence-template.md
+++ b/0000-evidence-template.md
@@ -39,9 +39,7 @@
 
 |  Ranks | Activity threshold  | Agreement threshold| Link | Notes |
 |---|---|---|---|---|
-|I  |90%   |N/A   | [Votes and Participation rate](https://collectives.subsquare.io/user/15DCWHQknBjc5YPFoVj8Pn2KoqrqYywJJ95BYNYJ4Fj3NLqz/votes) |*This is an example* |
-|I  |90%   |N/A   |   |  |
-|II |80%   |N/A   |   |  |
+|III|70%   |100%   [Regular voter across all referendum tracks](https://collectives.subsquare.io/user/13aYUFHB3umoPoxBEAHSv451iR3RpsNi3t5yBZjX2trCtTp6/votes) |*This is an example* |
 |III|70%   |100%  |   |  |
 |IV |60%   |90%   |   |  |
 |V  |50%   |80%   |   |  |

--- a/0000-evidence-template.md
+++ b/0000-evidence-template.md
@@ -39,7 +39,7 @@
 
 |  Ranks | Activity thresholds | Agreement thresholds | Member's voting activities | Comments |
 |---|---|---|---|---|
-|III|70%   |100%  |I have voted on ?? out of ?? referenda available to me, at my current rank (i.e ?? % voting activity). Out of ?? referenda where members of higher ranks were in complete agreement, I have voted in the opposite direction ?? times (i.e ?? % voting agreement).  |*This is an example.* |
+|III|70%   |100%  |I have voted on ?? out of ?? referenda in which I was eligible to vote (i.e ?? % voting activity). Out of ?? referenda in which members of higher ranks were in complete agreement, I have voted in line with the consensus ?? times (i.e ?? % voting agreement).  |*This is an example.* |
 |I  |90%   |N/A   |   |  |
 |II |80%   |N/A   |   |  |
 |III|70%   |100%  |   |  |

--- a/0000-evidence-template.md
+++ b/0000-evidence-template.md
@@ -40,6 +40,8 @@
 |  Ranks | Activity thresholds | Agreement thresholds | Links | Comments |
 |---|---|---|---|---|
 |III|70%   |100%  |[My votes](https://collectives.subsquare.io/user/13aYUFHB3umoPoxBEAHSv451iR3RpsNi3t5yBZjX2trCtTp6/votes) |*This is an example.* I have *[Never/Sometimes/Often/Always]* voted across all referendum tracks AND *[Never/Sometimes/Often/Always]* voted in line with expectations at rank. |
+|I  |90%   |N/A   |   |  |
+|II |80%   |N/A   |   |  |
 |III|70%   |100%  |   |  |
 |IV |60%   |90%   |   |  |
 |V  |50%   |80%   |   |  |

--- a/0000-evidence-template.md
+++ b/0000-evidence-template.md
@@ -39,7 +39,7 @@
 
 |  Ranks | Activity thresholds | Agreement thresholds | Member's voting activities | Comments |
 |---|---|---|---|---|
-|III|70%   |100%  |I have voted on ?? out of ?? referenda available to me, at my current rank (i.e ?? %). Out of ?? referenda where members of higher ranks were in complete agreement, I have voted in the opposite direction ?? times (i.e ?? %).  |*This is an example.* |
+|III|70%   |100%  |I have voted on ?? out of ?? referenda available to me, at my current rank (i.e ?? % voting activity). Out of ?? referenda where members of higher ranks were in complete agreement, I have voted in the opposite direction ?? times (i.e ?? % voting agreement).  |*This is an example.* |
 |I  |90%   |N/A   |   |  |
 |II |80%   |N/A   |   |  |
 |III|70%   |100%  |   |  |

--- a/0000-evidence-template.md
+++ b/0000-evidence-template.md
@@ -37,9 +37,9 @@
 ## Voting record
 *Provide your voting record in relation to required thresholds.* 
 
-|  Ranks | Activity threshold  | Agreement threshold| Link | Notes |
+|  Ranks | Activity thresholds | Agreement thresholds | Links | Comments |
 |---|---|---|---|---|
-|III|70%   |100%   [Regular voter across all referendum tracks](https://collectives.subsquare.io/user/13aYUFHB3umoPoxBEAHSv451iR3RpsNi3t5yBZjX2trCtTp6/votes) |*This is an example* |
+|III|70%   |100%  |[My votes](https://collectives.subsquare.io/user/13aYUFHB3umoPoxBEAHSv451iR3RpsNi3t5yBZjX2trCtTp6/votes) |*This is an example.* I have *[Never/Sometimes/Often/Always]* voted across all referendum tracks AND *[Never/Sometimes/Often/Always]* voted in line with expectations at rank. |
 |III|70%   |100%  |   |  |
 |IV |60%   |90%   |   |  |
 |V  |50%   |80%   |   |  |

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ All members that have been inducted for standard allowance as per the [Fellowshi
 
 All members (Ranks I-VI) must serve a minimum period of service of 12 months at their current rank before seeking promotion to a higher rank. There is no minimum period of service for Candidates seeking to become members.
 
-Members seeking retentions or promotions for Rank III-VI will need to reflect on their voting record in relation to the thresholds for voting "activity" and voting "agreement" described in section 4.5.4 of the Manifesto. 
+Members seeking retentions or promotions for Rank III-VI will need to reflect on their voting record in relation to the thresholds for voting "activity" and voting "agreement" described in the Manifesto. 
 
 Members seeking promotions for Rank III-VI are required to attend an **in-person interview** before their request can be moved to on-chain voting.
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,9 @@ All members that have been inducted for standard allowance as per the [Fellowshi
 
 All members (Ranks I-VI) must serve a minimum period of service of 12 months at their current rank before seeking promotion to a higher rank. There is no minimum period of service for Candidates seeking to become members.
 
-Members seeking retentions or promotions for Rank III-VI will need to reflect on their voting record in relation to the thresholds for voting "activity" and voting "agreement" described in section 4.5.4 of the Manifesto. Members seeking promotions for Rank III-VI are required to attend an **in-person interview** before their request can be moved to on-chain voting.
+Members seeking retentions or promotions for Rank III-VI will need to reflect on their voting record in relation to the thresholds for voting "activity" and voting "agreement" described in section 4.5.4 of the Manifesto. 
+
+Members seeking promotions for Rank III-VI are required to attend an **in-person interview** before their request can be moved to on-chain voting.
 
 
 ## Timelines

--- a/README.md
+++ b/README.md
@@ -44,9 +44,9 @@ All members that have been inducted for standard allowance as per the [Fellowshi
 
 All members (Ranks I-VI) must serve a minimum period of service of 12 months at their current rank before seeking promotion to a higher rank. There is no minimum period of service for Candidates seeking to become members.
 
-Members seeking retentions or promotions for Rank III-VI will need to reflect on their voting record in relation to the thresholds for voting "activity" and voting "agreement" described in the Manifesto. 
+All Members seeking retentions or promotions will need to reflect on their voting record in relation to the thresholds for voting "activity" and voting "agreement" described in the Manifesto. 
 
-Members seeking promotions for Rank III-VI are required to attend an **in-person interview** so that their request can be moved to on-chain voting. The Fellowship Sub-Treasury can cover all costs incurred while attending these in-person evaluations. 
+Members seeking promotions for Rank III-VI are required to attend an **in-person interview** before their request can be moved to on-chain voting. The Fellowship Sub-Treasury can cover all costs incurred while attending these in-person evaluations. 
 
 
 ## Timelines

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ All members that have been inducted for standard allowance as per the [Fellowshi
 
 All members (Ranks I-VI) must serve a minimum period of service of 12 months at their current rank before seeking promotion to a higher rank. There is no minimum period of service for Candidates seeking to become members.
 
-Members seeking retention or promotion at Rank III-VI will need to reflect on their voting record in relation to the thresholds for voting "activity" and voting "agreement" described in section 4.5.4 of the Manifesto.
+Members seeking retentions or promotions for Rank III-VI will need to reflect on their voting record in relation to the thresholds for voting "activity" and voting "agreement" described in section 4.5.4 of the Manifesto. Members seeking promotions for Rank III-VI are required to attend an **in-person interview** before their request can be moved to on-chain voting.
 
 
 ## Timelines

--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ All members that have been inducted for standard allowance as per the [Fellowshi
 
 All members (Ranks I-VI) must serve a minimum period of service of 12 months at their current rank before seeking promotion to a higher rank. There is no minimum period of service for Candidates seeking to become members.
 
+Members seeking retention or promotion at Rank III-VI will need to reflect on their voting record in relation to the thresholds for voting "activity" and voting "agreement" described in section 4.5.4 of the Manifesto.
+
 
 ## Timelines
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ All members (Ranks I-VI) must serve a minimum period of service of 12 months at 
 
 Members seeking retentions or promotions for Rank III-VI will need to reflect on their voting record in relation to the thresholds for voting "activity" and voting "agreement" described in the Manifesto. 
 
-Members seeking promotions for Rank III-VI are required to attend an **in-person interview** before their request can be moved to on-chain voting.
+Members seeking promotions for Rank III-VI are required to attend an **in-person interview** so that their request can be moved to on-chain voting. The Fellowship Sub-Treasury can cover all costs incurred while attending these in-person evaluations. 
 
 
 ## Timelines

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Members seeking retention or promotion at Rank III-VI will need to reflect on th
 ## Timelines
 
 Members should individually monitor the progress of their demotion and promotion periods on the [Core Fellowship UI](https://collectives.subsquare.io/fellowship/core) provided by Subsquare. Alternatively, members can check their individual status directly on the chain state via [Polkadot-JS](https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Fsys.ibp.network%2Fcollectives-polkadot#/chainstate).
+
 Members can also add an ical feed for Fellowship-related data directly into their email client or their Google account using this link: **webcal://fellowship-calendar.kchr.de/?account=YOUR_ACCOUNT_ID**. The code for this widget can be found [here](https://github.com/bkchr/fellowship-ical). 
 
 It is recommended that members submit their evidence for review (via GitHub) and on-chain (via Subsquare) as per the following deadlines:


### PR DESCRIPTION
The manifesto states that:
-	all members should provide information about their voting records for retention/promotion requests (section 4.5.4)
![Voting Overview](https://github.com/user-attachments/assets/77b76eb9-802e-4179-8ff9-fc9a7a5bfb75)

-	members of Rank 3+ should attend an in-person interview for promotion requests (section 6.4.1)
![Rank3 promotions requirements](https://github.com/user-attachments/assets/77016223-ae99-45cb-b90b-2fe3a8ba4c3c)

This PR adds new information in the Evidences docs in line with these requirements.

